### PR TITLE
[fix] typings emit

### DIFF
--- a/packages/signia/src/Computed.ts
+++ b/packages/signia/src/Computed.ts
@@ -40,9 +40,6 @@ export const isUninitialized = (value: any): value is UNINITIALIZED => {
 	return value === UNINITIALIZED
 }
 
-/**
- * @internal
- */
 class WithDiff<Value, Diff> {
 	constructor(public value: Value, public diff: Diff) {}
 }

--- a/tests/package-build/src/signia.test.ts
+++ b/tests/package-build/src/signia.test.ts
@@ -17,9 +17,13 @@ test('i can import `atom` and use it in a .ts file and typescript is cool with t
 	execSync('npx tsc --init', { cwd: dir })
 	writeFileSync(
 		`${dir}/test.ts`,
-		`import {atom} from 'signia'; console.log(atom('test', 'value').value)`
+		`import {atom, computed} from 'signia';
+		const a = atom('test', 'value');
+		const b = computed('test', () => a.value);
+		console.log('total:', a.value.length + b.value.length)
+		`
 	)
-	execSync('npx tsc', { cwd: dir })
+	execSync('npx tsc', { cwd: dir, stdio: 'inherit' })
 	const output = execSync(`node test.js`, { cwd: dir, encoding: 'utf8' }).trim()
-	expect(output).toBe('value')
+	expect(output).toBe('total: 10')
 })


### PR DESCRIPTION
This PR fixes a build issue that was causing api-extractor to omit a key type from the typings rollup. It also adds a better e2e package test to catch similar issues in the future.