### PR TITLE
Fix react bindings doc links

### DIFF
--- a/docs/docs/react-bindings.mdx
+++ b/docs/docs/react-bindings.mdx
@@ -10,10 +10,10 @@ import TabItem from '@theme/TabItem'
 We provide officially-supported React bindings for `signia` in two packages:
 
 - `signia-react` provides hooks for creating and consuming signals in functional components.
-  - [`useAtom`](docs/API/signia_react/functions/useAtom) - A hook for creating atomic signals.
-  - [`useComputed`](docs/API/signia_react/functions/useAtom) - A hook for creating computed signals.
-  - [`track`](docs/API/signia_react/functions/useAtom) - component wrapper for automatically tracking signal value access and re-rendering the wrapped component if the signals' values change.
-  - [`useValue`](docs/API/signia_react/functions/useAtom) - A hook for manually tracking signal value access (not required if you use `track`)
+  - [`useAtom`](/API/signia_react/functions/useAtom) - A hook for creating atomic signals.
+  - [`useComputed`](/API/signia_react/functions/useAtom) - A hook for creating computed signals.
+  - [`track`](/API/signia_react/functions/useAtom) - component wrapper for automatically tracking signal value access and re-rendering the wrapped component if the signals' values change.
+  - [`useValue`](/API/signia_react/functions/useAtom) - A hook for manually tracking signal value access (not required if you use `track`)
 - `signia-react-jsx` provides a minimal global jsx integration for use with TypeScript's `jsxImportSource` option. This causes all functional components to be automatically
   tracked.
 

--- a/docs/docs/react-bindings.mdx
+++ b/docs/docs/react-bindings.mdx
@@ -10,10 +10,10 @@ import TabItem from '@theme/TabItem'
 We provide officially-supported React bindings for `signia` in two packages:
 
 - `signia-react` provides hooks for creating and consuming signals in functional components.
-  - [`useAtom`](/API/signia_react/functions/useAtom) - A hook for creating atomic signals.
-  - [`useComputed`](/API/signia_react/functions/useAtom) - A hook for creating computed signals.
-  - [`track`](/API/signia_react/functions/useAtom) - component wrapper for automatically tracking signal value access and re-rendering the wrapped component if the signals' values change.
-  - [`useValue`](/API/signia_react/functions/useAtom) - A hook for manually tracking signal value access (not required if you use `track`)
+  - [`useAtom`](API/signia_react/functions/useAtom) - A hook for creating atomic signals.
+  - [`useComputed`](API/signia_react/functions/useAtom) - A hook for creating computed signals.
+  - [`track`](API/signia_react/functions/useAtom) - component wrapper for automatically tracking signal value access and re-rendering the wrapped component if the signals' values change.
+  - [`useValue`](API/signia_react/functions/useAtom) - A hook for manually tracking signal value access (not required if you use `track`)
 - `signia-react-jsx` provides a minimal global jsx integration for use with TypeScript's `jsxImportSource` option. This causes all functional components to be automatically
   tracked.
 


### PR DESCRIPTION
Links on the React bindings page are broken, they contain an additional `/docs`. This should fix it.