### PR TITLE
[wip] push nodes impl

### DIFF
--- a/packages/signia/src/Computed.ts
+++ b/packages/signia/src/Computed.ts
@@ -98,6 +98,8 @@ export interface ComputedOptions<Value, Diff> {
 	 * @returns
 	 */
 	isEqual?: (a: any, b: any) => boolean
+
+	isPush?: boolean
 }
 
 /**
@@ -140,6 +142,7 @@ export class _Computed<Value, Diff = unknown> implements Computed<Value, Diff> {
 	}
 
 	historyBuffer?: HistoryBuffer<Diff>
+	isPush: boolean
 
 	// The last-computed value of this signal.
 	private state: Value = UNINITIALIZED as unknown as Value
@@ -167,6 +170,7 @@ export class _Computed<Value, Diff = unknown> implements Computed<Value, Diff> {
 		}
 		this.computeDiff = options?.computeDiff
 		this.isEqual = options?.isEqual ?? null
+		this.isPush = options?.isPush ?? false
 	}
 
 	__unsafe__getWithoutCapture(): Value {

--- a/packages/signia/src/__tests__/computed.test.ts
+++ b/packages/signia/src/__tests__/computed.test.ts
@@ -587,3 +587,24 @@ describe(getComputedInstance, () => {
 		expect(bInst).toBeInstanceOf(_Computed)
 	})
 })
+
+describe('push computeds', () => {
+	it('prevent traversal', () => {
+		const user = atom('', { id: 1, name: 'steve' })
+		const name = computed('', () => user.value.name, { isPush: true })
+		const nameLength = computed('', () => name.value.length)
+		let numNameLengthReactions = 0
+		const r = reactor('', () => {
+			numNameLengthReactions++
+			nameLength.value
+		})
+		r.start()
+		expect(numNameLengthReactions).toBe(1)
+		const lastTraversed = r.scheduler.lastTraversedEpoch
+
+		user.set({ id: 2, name: 'steve' })
+
+		expect(numNameLengthReactions).toBe(1)
+		expect(r.scheduler.lastTraversedEpoch).toBe(lastTraversed)
+	})
+})


### PR DESCRIPTION
This PR maybe adds eagerly-updated 'push' nodes, which can be used selectively to avoid traversing sections of the graph, and to set historyLength to 1 in some cases.

when you call atom.set, whether in a transaction or not, if the atom has any direct 'push' children, those children will be updated immediately. And if those children have any direct 'push' children they will also be updated immediately, and so on.

Then when the final reaction sweep is done when the root transaction commits, if a push node is encountered which did not change during the transaction, it is not traversed.


Before merging:
- Need to make sure that this actually performs better in some situations
- Add `numPushyChildren` to atoms/computeds to allow avoiding push traversal. Or maybe use a separate lazily-instantiated ArraySet?