### PR TITLE
prevent useValue from throwing when used in a zombie-child

### DIFF
--- a/packages/signia-react/src/track.test.tsx
+++ b/packages/signia-react/src/track.test.tsx
@@ -181,3 +181,47 @@ test('things referenced in effects do not trigger updates', async () => {
 	expect(numRenders).toBe(1)
 	expect(view!.toJSON()).toMatchInlineSnapshot(`"hi"`)
 })
+
+test("tracked zombie-children don't throw", async () => {
+	const theAtom = atom<Record<string, number>>('map', { a: 1, b: 2, c: 3 })
+	const Parent = track(function Parent() {
+		const ids = Object.keys(theAtom.value)
+		return (
+			<>
+				{ids.map((id) => (
+					<Child key={id} id={id} />
+				))}
+			</>
+		)
+	})
+	const Child = track(function Child({ id }: { id: string }) {
+		if (!(id in theAtom.value)) throw new Error('id not found!')
+		const value = theAtom.value[id]
+		return <>{value}</>
+	})
+
+	let view: ReactTestRenderer
+	await act(() => {
+		view = create(<Parent />)
+	})
+
+	expect(view!.toJSON()).toMatchInlineSnapshot(`
+		[
+		  "1",
+		  "2",
+		  "3",
+		]
+	`)
+
+	// remove id 'b' creating a zombie-child
+	await act(() => {
+		theAtom?.update(({ b: _, ...rest }) => rest)
+	})
+
+	expect(view!.toJSON()).toMatchInlineSnapshot(`
+		[
+		  "1",
+		  "3",
+		]
+	`)
+})

--- a/packages/signia-react/src/useValue.test.tsx
+++ b/packages/signia-react/src/useValue.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import ReactTestRenderer from 'react-test-renderer'
-import { Atom, Computed } from 'signia'
+import { Atom, atom, Computed } from 'signia'
 import { useAtom } from './useAtom.js'
 import { useComputed } from './useComputed.js'
 import { useValue } from './useValue.js'
@@ -81,4 +81,54 @@ test('useValue returns a value from a compute function', async () => {
 		setB!(5)
 	})
 	expect(view!.toJSON()).toMatchInlineSnapshot(`"10"`)
+})
+
+test("useValue doesn't throw when used in a zombie-child component", async () => {
+	const theAtom = atom<Record<string, number>>('map', { a: 1, b: 2, c: 3 })
+	function Parent() {
+		const ids = useValue('ids', () => Object.keys(theAtom.value), [])
+		return (
+			<>
+				{ids.map((id) => (
+					<Child key={id} id={id} />
+				))}
+			</>
+		)
+	}
+	function Child({ id }: { id: string }) {
+		const value = useValue(
+			'value',
+			() => {
+				if (!(id in theAtom.value)) throw new Error('id not found!')
+				return theAtom.value[id]
+			},
+			[id]
+		)
+		return <>{value}</>
+	}
+
+	let view: ReactTestRenderer.ReactTestRenderer
+	await ReactTestRenderer.act(() => {
+		view = ReactTestRenderer.create(<Parent />)
+	})
+
+	expect(view!.toJSON()).toMatchInlineSnapshot(`
+		[
+		  "1",
+		  "2",
+		  "3",
+		]
+	`)
+
+	// remove id 'b' creating a zombie-child
+	await ReactTestRenderer.act(() => {
+		theAtom?.update(({ b: _, ...rest }) => rest)
+	})
+
+	expect(view!.toJSON()).toMatchInlineSnapshot(`
+		[
+		  "1",
+		  "3",
+		]
+	`)
 })


### PR DESCRIPTION
I ran into this problem when porting some of my own projects from my custom reactive lib over to signia. I'd implemented this for my lib so thought i'd port it over!

Let's say you have an atom containing a map from IDs to values, and a parent component that iterates over the keys and passes each to a child component which looks up the value corresponding to the key, and throws if the value isn't present. What happens when you delete a key from the map?

If you implement this using `track`, you're all good - `track` doesn't re-execute your component, it just schedules a re-render with react for both the parent and child. When react re-renders, it'll start with the parent, see that an ID has been removed, and unmount that child rather than re-render it - so no error.

If you implement this using `useValue` though, all the relevant derivations will re-execute right away & only schedule a react re-render if they've changed. The derivation in the deleted child will throw at the end of the signia transaction containing the update and your app will crash.

This diff prevents this from happening by swallowing errors that occur in a `useValue` derivation if they happen outside of the react render from the component in question, and instead just forcing a react rerender. The derivation will be executed again in render, and throw "for real" then. This sounds a little sketchy at first, but it's pretty widely used. Redux does this too:
> useSelector() tries to deal with this by catching all errors that are thrown when the selector is executed due to a store update (but not when it is executed during rendering). When an error occurs, the component will be forced to render, at which point the selector is executed again. This works as long as the selector is a pure function and you do not depend on the selector throwing errors.
> https://react-redux.js.org/api/hooks

and react's own `useSyncExternalStore` shim does too: https://github.com/facebook/react/blob/657698e48d5b093b4ea5a7684e26d3fdd16695f2/packages/use-sync-external-store/src/useSyncExternalStoreShimClient.js#L137-L142

The only reason we can't rely on react's behaviour here is because signia is executing the derivation outside of what react knows about.

With this change, when a key is deleted in our scenario, signia will re-execute the derivations and see the parent has changed, so it'll schedule a re-render for that, it'll see that the deleted child is now throwing, so it'll schedule a re-render for that, and it'll see that the other children are unchanged, so don't need re-rendering. React will re-render the parent first, see that the child is deleted, and unmount it without re-rendering the other children

