### PR TITLE
[fix] isEqual usage in computed

### DIFF
--- a/packages/signia/src/Computed.ts
+++ b/packages/signia/src/Computed.ts
@@ -181,7 +181,7 @@ export class _Computed<Value, Diff = unknown> implements Computed<Value, Diff> {
 			startCapturingParents(this)
 			const result = this.derive(this.state, this.lastCheckedEpoch)
 			const newState = result instanceof WithDiff ? result.value : result
-			if (!this.isEqual(newState, this.state)) {
+			if (this.state === UNINITIALIZED || !this.isEqual(newState, this.state)) {
 				if (this.historyBuffer && !isNew) {
 					const diff = result instanceof WithDiff ? result.diff : undefined
 					this.historyBuffer.pushEntry(

--- a/packages/signia/src/__tests__/computed.test.ts
+++ b/packages/signia/src/__tests__/computed.test.ts
@@ -587,3 +587,24 @@ describe(getComputedInstance, () => {
 		expect(bInst).toBeInstanceOf(_Computed)
 	})
 })
+
+describe('computed isEqual', () => {
+	it('does not get called for the initialization', () => {
+		const isEqual = jest.fn((a, b) => a === b)
+
+		const a = atom('a', 1)
+		const b = computed('b', () => a.value * 2, { isEqual })
+
+		expect(b.value).toBe(2)
+		expect(isEqual).not.toHaveBeenCalled()
+		expect(b.value).toBe(2)
+		expect(isEqual).not.toHaveBeenCalled()
+
+		a.set(2)
+
+		expect(b.value).toBe(4)
+		expect(isEqual).toHaveBeenCalledTimes(1)
+		expect(b.value).toBe(4)
+		expect(isEqual).toHaveBeenCalledTimes(1)
+	})
+})


### PR DESCRIPTION
- don't call `isEqual` on `UNINITIALIZED`