### PR TITLE
Fix issue in useValue example

### DIFF
--- a/docs/docs/react-bindings.mdx
+++ b/docs/docs/react-bindings.mdx
@@ -60,7 +60,7 @@ type MyComponentProps = { getFoo: (n: number) => Bar }
 const MyComponent: React.FC<MyComponentProps> = (props: MyComponentProps) => {
 	// getFoo uses a signal under the hood, but we don't have direct access to that signal.
 	const n = 42
-	const foo: Bar = useValue('foo', () => props.getFoo(42), [props.getFoo, n])
+	const foo: Bar = useValue('foo', () => props.getFoo(n), [props.getFoo, n])
 	// ...
 }
 ```


### PR DESCRIPTION
For the useValue example for passing a 'compute' function, it have a dependency of `n` which is never used.

Previously:
```ts
type MyComponentProps = { getFoo: (n: number) => Bar }
const MyComponent: React.FC<MyComponentProps> = (props: MyComponentProps) => {
    // getFoo uses a signal under the hood, but we don't have direct access to that signal.
    const n = 42
    const foo: Bar = useValue('foo', () => props.getFoo(42), [props.getFoo, n])
    // ...
}
```

Fix:
```ts
type MyComponentProps = { getFoo: (n: number) => Bar }
const MyComponent: React.FC<MyComponentProps> = (props: MyComponentProps) => {
    // getFoo uses a signal under the hood, but we don't have direct access to that signal.
    const n = 42
    const foo: Bar = useValue('foo', () => props.getFoo(n), [props.getFoo, n])
    // ...
}
```